### PR TITLE
Added logo 

### DIFF
--- a/studentportal-client/src/Components/AccountDetails.js
+++ b/studentportal-client/src/Components/AccountDetails.js
@@ -51,7 +51,7 @@ const AccountDetails = ({ user }) => {
                 label="LinkedIn"
                 value={user.linkedInUrl}
                 InputProps={{
-                    readOnly: true,
+                    readOnly: false,
                 }}
             />
             <TextField

--- a/studentportal-client/src/Components/Labs.js
+++ b/studentportal-client/src/Components/Labs.js
@@ -4,6 +4,7 @@ import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 import ListItemIcon from '@mui/material/ListItemIcon';
+import GitHubIcon from '@mui/icons-material/GitHub';
 
 const Labs = ({labs}) => {
     return (
@@ -12,7 +13,7 @@ const Labs = ({labs}) => {
             {labs?.map((lab, i) =>
                 <ListItem key={i}>
                     <ListItemIcon>
-                        <PictureAsPdfIcon />
+                        <GitHubIcon />
                     </ListItemIcon>
                     <Link href={lab.labUrl} target="blank">{lab.labName}</Link>
                     <p> {lab.description} </p>

--- a/studentportal-client/src/Components/Navbar.js
+++ b/studentportal-client/src/Components/Navbar.js
@@ -35,7 +35,10 @@ const Navbar = (props) => {
 
   const drawer = (
     <div>
-      <Toolbar sx={{ bgcolor: "primary" }} />
+      <Toolbar
+        sx={{ color: "white", backgroundColor: "rgb(25, 118, 210)", justifyContent:"center" }}>
+        <img src="https://precourse.salt.study/_next/static/media/salt-logo-white.3c845df7.svg" alt="salt" width="100px" />
+      </Toolbar>
       <Divider />
       <List>
         {['Account', 'Topics', 'Labs', 'Assignments'].map((text, index) => (
@@ -55,6 +58,7 @@ const Navbar = (props) => {
         ))}
       </List>
       <Divider />
+    
     </div>
   );
 

--- a/studentportal-client/src/Components/Presentation.js
+++ b/studentportal-client/src/Components/Presentation.js
@@ -7,6 +7,9 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 
 
 const Presentation = ({ pres }) => {
+    if (!pres || pres.length == 0) {
+        return <p>There are no slides for the topic yet...</p>
+    }
     return (
         <>
             <List>

--- a/studentportal-client/src/Components/Videos.js
+++ b/studentportal-client/src/Components/Videos.js
@@ -1,10 +1,19 @@
 import React from 'react';
 
-const Videos = (videos) => {
+const Videos = ({ videos }) => {
+    if (!videos || videos.length == 0) {
+        return <p>There is no videos for the topic yet...</p>
+    }
     return (
         <>
-            <iframe src="https://drive.google.com/file/d/1AEtGePW6337n6ykJs6LXjLX3_bAV5-IG/preview" width="320" height="240"
-                allowFullScreen allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe>
+            {videos.map(v =>
+                <div>
+                    <iframe src={v.videoUrl} width="320" height="240"
+                        allowFullScreen allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe>
+                    <p>{v.videoName}</p>
+                </div>
+            )}
+
         </>
     );
 }

--- a/studentportal-client/src/Components/WeekTopics.js
+++ b/studentportal-client/src/Components/WeekTopics.js
@@ -7,6 +7,7 @@ import { useAuth0 } from "@auth0/auth0-react";
 import LoadingPage from './LoadingPage';
 import ErrorPage from './ErrorPage';
 import AccountHeader from './AccountHeader';
+import WeekTopicsHeader from './WeekTopicsHeader';
 import {
   BrowserRouter as Router,
   Switch,
@@ -54,7 +55,7 @@ export default function WeekTopics() {
 
   return (
     <>
-      <AccountHeader user={user} />
+      <WeekTopicsHeader />
       <Stack
         direction="row"
         justifyContent="center"

--- a/studentportal-client/src/Components/WeekTopicsHeader.js
+++ b/studentportal-client/src/Components/WeekTopicsHeader.js
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const WeekTopicsHeader = ({ title }) => {
+    return (
+        <>
+            <h1>Topics</h1>
+            <p>Aka Schedule</p>
+        </>
+    );
+}
+
+export default WeekTopicsHeader;


### PR DESCRIPTION
1. `Sidebar`: added salt's logo to the top
2. `Topics/Labs`: changed pdf-ico to github-logo
3. `Topics/Presentation`: added default text if the list of presentations is empty
4. `Topics/Videos`: added default text if the list of videos is empty & added rendering for the list of videos
5. `WeekTopics`: changed header